### PR TITLE
Add SandboxPurchase() in client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@piavart/rustore-client",
-  "version": "0.0.1-alfa.2",
+  "version": "0.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@piavart/rustore-client",
-      "version": "0.0.1-alfa.2",
+      "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.24.0",

--- a/src/client.ts
+++ b/src/client.ts
@@ -30,6 +30,14 @@ export class RuStoreClient {
     return result.body;
   }
 
+  public async getSandboxPurchase(purchaseToken: string): Promise<RS_Purchace> {
+    const result = await this.request<TBaseResponse<RS_Purchace>>(
+      `${Path.SandboxPurchase}${purchaseToken}`,
+    );
+
+    return result.body;
+  }
+
   public async getSubscription(
     purchaseToken: string,
   ): Promise<RS_SubscriptionResponse_Body> {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,5 +3,6 @@ export const API_URL = 'https://public-api.rustore.ru';
 export enum Path {
   Auth = '/public/auth/',
   Purchase = '/public/purchase/',
+  SandboxPurchase = '/public/sandbox/purchase/',
   Subscription = '/public/subscription/',
 }


### PR DESCRIPTION
Finally, I know the reason of my issue - the test payment and sandbox environment.

Because I used a test user to do payment, so every payment is a test payment. The purchase query API should be /public/sandbox/purchase.

I add  SandboxPurchase() method in client.