### PR TITLE
Move from `crypto` to `jsrsasign` as more universal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,20 @@
 {
   "name": "@piavart/rustore-client",
-  "version": "0.0.2",
+  "version": "0.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@piavart/rustore-client",
-      "version": "0.0.2",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.24.0",
-        "crypto": "^1.0.1",
+        "jsrsasign": "^11.1.0",
         "strftime": "^0.10.2"
       },
       "devDependencies": {
+        "@types/jsrsasign": "^10.5.14",
         "@types/node": "^18.17.6",
         "@types/strftime": "^0.9.4",
         "@typescript-eslint/eslint-plugin": "^5.62.0",
@@ -162,6 +163,12 @@
       "version": "7.0.12",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz",
       "integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==",
+      "dev": true
+    },
+    "node_modules/@types/jsrsasign": {
+      "version": "10.5.14",
+      "resolved": "https://registry.npmjs.org/@types/jsrsasign/-/jsrsasign-10.5.14.tgz",
+      "integrity": "sha512-lppSlfK6etu+cuKs40K4rg8As79PH6hzIB+v55zSqImbSH3SE6Fm8MBHCiI91cWlAP3Z4igtJK1VL3fSN09blQ==",
       "dev": true
     },
     "node_modules/@types/node": {
@@ -566,12 +573,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/crypto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/crypto/-/crypto-1.0.1.tgz",
-      "integrity": "sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig==",
-      "deprecated": "This package is no longer supported. It's now a built-in Node module. If you've depended on crypto, you should switch to the one that's built-in."
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -1151,6 +1152,14 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
+    },
+    "node_modules/jsrsasign": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-11.1.0.tgz",
+      "integrity": "sha512-Ov74K9GihaK9/9WncTe1mPmvrO7Py665TUfUKvraXBpu+xcTWitrtuOwcjf4KMU9maPaYn0OuaWy0HOzy/GBXg==",
+      "funding": {
+        "url": "https://github.com/kjur/jsrsasign#donations"
+      }
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -1802,6 +1811,12 @@
       "integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==",
       "dev": true
     },
+    "@types/jsrsasign": {
+      "version": "10.5.14",
+      "resolved": "https://registry.npmjs.org/@types/jsrsasign/-/jsrsasign-10.5.14.tgz",
+      "integrity": "sha512-lppSlfK6etu+cuKs40K4rg8As79PH6hzIB+v55zSqImbSH3SE6Fm8MBHCiI91cWlAP3Z4igtJK1VL3fSN09blQ==",
+      "dev": true
+    },
     "@types/node": {
       "version": "18.17.6",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.6.tgz",
@@ -2069,11 +2084,6 @@
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
       }
-    },
-    "crypto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/crypto/-/crypto-1.0.1.tgz",
-      "integrity": "sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig=="
     },
     "debug": {
       "version": "4.3.4",
@@ -2493,6 +2503,11 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
+    },
+    "jsrsasign": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-11.1.0.tgz",
+      "integrity": "sha512-Ov74K9GihaK9/9WncTe1mPmvrO7Py665TUfUKvraXBpu+xcTWitrtuOwcjf4KMU9maPaYn0OuaWy0HOzy/GBXg=="
     },
     "levn": {
       "version": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@piavart/rustore-client",
-  "version": "0.2.1",
+  "version": "0.2.1-jsrsasign",
   "description": "nodejs rustore client",
   "author": "Arseny Vorobyov <piavarts@gmail.com>",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@piavart/rustore-client",
-  "version": "0.2.1-jsrsasign",
+  "version": "0.2.1-jsrsasign1",
   "description": "nodejs rustore client",
   "author": "Arseny Vorobyov <piavarts@gmail.com>",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -20,10 +20,11 @@
   "license": "MIT",
   "dependencies": {
     "axios": "^0.24.0",
-    "crypto": "^1.0.1",
+    "jsrsasign": "^11.1.0",
     "strftime": "^0.10.2"
   },
   "devDependencies": {
+    "@types/jsrsasign": "^10.5.14",
     "@types/node": "^18.17.6",
     "@types/strftime": "^0.9.4",
     "@typescript-eslint/eslint-plugin": "^5.62.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@piavart/rustore-client",
-  "version": "0.2.1-jsrsasign1",
+  "version": "0.2.2",
   "description": "nodejs rustore client",
   "author": "Arseny Vorobyov <piavarts@gmail.com>",
   "main": "dist/index.js",

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -4,7 +4,8 @@ import * as strftime from 'strftime';
 
 import { API_URL, Path } from './constants';
 import { RuStoreError } from './errors';
-import { TAuthResponse, TErrorResponse } from './types';
+import { TAuthResponse } from './types';
+import { getRustoreError } from './utils/get-rustore-error';
 
 export class RSAuth {
   private readonly httpClient = axios.create({ baseURL: API_URL });
@@ -47,9 +48,7 @@ export class RSAuth {
       this.$jwe = result.data.body.jwe;
       this.sessionEnd = date.valueOf() + (result.data.body.ttl - 10) * 1000;
     } catch (e: any) {
-      const data = e.response.data as TErrorResponse;
-
-      throw new RuStoreError(data);
+      throw new RuStoreError(getRustoreError(e));
     }
   }
 

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { createSign } from 'crypto';
+import { KEYUTIL, KJUR, RSAKey, hextob64 } from 'jsrsasign';
 import * as strftime from 'strftime';
 
 import { API_URL, Path } from './constants';
@@ -8,7 +8,7 @@ import { TAuthResponse, TErrorResponse } from './types';
 
 export class RSAuth {
   private readonly httpClient = axios.create({ baseURL: API_URL });
-  private readonly privateKey: string;
+  private readonly privateKey: RSAKey;
 
   private $jwe: string | undefined;
   private sessionEnd: number | undefined;
@@ -18,7 +18,9 @@ export class RSAuth {
     privateKey: string,
     private readonly keyId: number,
   ) {
-    this.privateKey = `-----BEGIN PRIVATE KEY-----\n${privateKey}\n-----END PRIVATE KEY-----`;
+    this.privateKey = KEYUTIL.getKey(
+      `-----BEGIN PRIVATE KEY-----\n${privateKey}\n-----END PRIVATE KEY-----`,
+    ) as RSAKey;
   }
 
   public async auth() {
@@ -28,10 +30,12 @@ export class RSAuth {
 
     const str = `${this.keyId}${dateStr}`;
 
-    const sign = createSign('RSA-SHA512');
-    sign.write(str);
-    sign.end();
-    const signature = sign.sign(this.privateKey, 'base64');
+    const sig = new KJUR.crypto.Signature({ alg: 'SHA512withRSA' });
+    sig.init(this.privateKey);
+    sig.updateString(str);
+    const signatureHex = sig.sign();
+    const signatureBase64 = hextob64(signatureHex);
+    const signature = signatureBase64;
 
     try {
       const result = await this.httpClient.post<TAuthResponse>(Path.Auth, {

--- a/src/client.ts
+++ b/src/client.ts
@@ -10,7 +10,8 @@ import {
   RS_SubscriptionState,
   RS_VersionsResponse_Body,
 } from './interfaces';
-import { TBaseResponse, TErrorResponse } from './types';
+import { TBaseResponse } from './types';
+import { getRustoreError } from './utils/get-rustore-error';
 
 export class RuStoreClient {
   private readonly auth: RSAuth;
@@ -123,17 +124,7 @@ export class RuStoreClient {
 
       return result.data;
     } catch (e: any) {
-      const data = e.response.data as TErrorResponse | '';
-
-      if (!data) {
-        throw new RuStoreError({
-          code: 'ERROR',
-          message: e.response.statusText,
-          timestamp: '',
-        });
-      }
-
-      throw new RuStoreError(data);
+      throw new RuStoreError(getRustoreError(e));
     }
   }
 }

--- a/src/utils/get-rustore-error.ts
+++ b/src/utils/get-rustore-error.ts
@@ -1,0 +1,11 @@
+import { TErrorResponse } from '../types';
+
+export function getRustoreError(e: any): TErrorResponse {
+  if (e.data) return e.data;
+  if (e.response?.data) return e.response.data;
+  return {
+    code: 'ERROR',
+    message: '',
+    timestamp: '',
+  };
+}


### PR DESCRIPTION
The use of a `crypto` module imposes restrictions on some use cases. In particular, I cannot use your library in my expo project (The error looks like: `attempted to import the Node standard library module "crypto". It failed because the native React runtime does not include the Node standard library`). 

`jsrsasign` is free of such restrictions (tested both in a Node environment and in an Expo project. It works without any fails for me).

Perhaps the use of `crypto` was intentional; if this is so, then we can move the `auth` module into a separate library and integrate it separately to the your client. 
Then whoever needs it will use this separated library with `crypto`, and whoever needs it will use a self-written class (for example, using `jsrsasign`).